### PR TITLE
Lógica para validar creación de ferias y evitar duplicaciones

### DIFF
--- a/src/modules/fairs/services/fair.service.ts
+++ b/src/modules/fairs/services/fair.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from "@nestjs/common";
+import { ConflictException, Injectable, InternalServerErrorException } from "@nestjs/common";
 import { Fair } from "../entities/fair.entity";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { DataSource, QueryFailedError, Repository } from "typeorm";
 import { fairDto } from "../dto/createFair.dto";
 import { UpdatefairDto } from "../dto/updateFair.dto";
 import { fairStatusDto } from "../dto/fair-status.dto";
@@ -11,18 +11,58 @@ export class FairService {
     constructor(
         @InjectRepository(Fair)
         private fairRepository: Repository<Fair>,
-        private standService: StandService
+        private standService: StandService,
+        private dataSource: DataSource
     ) { }
 
-    async create(createfairDto: fairDto) {
-        const newfair = this.fairRepository.create({
-            ...createfairDto,
-            date: new Date(createfairDto.date) // Convierte el stirng al tipo de dato date antes de enviar a la base de datos
-        });
-        const savedfair = await this.fairRepository.save(newfair);
+    async create(createfairDto: fairDto): Promise<Fair> {
+        const queryRunner = this.dataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
 
-        await this.standService.createInitialStands(savedfair.id_fair, savedfair.stand_capacity);
-        return savedfair;
+        try {
+            const existingFair = await queryRunner.manager.findOne(Fair, {
+                where: {
+                    name: createfairDto.name,
+                    date: new Date(createfairDto.date)
+                }
+            });
+            if (existingFair) {
+                throw new ConflictException(
+                    'Ya existe una feria con el mismo nombre y fecha. Por favor, verifica los datos e intenta nuevamente.'
+                );
+            }
+
+            const newfair = queryRunner.manager.create(Fair, {
+                ...createfairDto,
+                date: new Date(createfairDto.date) // Convierte el stirng al tipo de dato date antes de enviar a la base de datos
+            });
+
+            const savedfair = await queryRunner.manager.save(Fair, newfair);
+
+            await this.standService.createInitialStands(savedfair.id_fair, savedfair.stand_capacity, queryRunner);
+
+            await queryRunner.commitTransaction();
+            return savedfair;
+
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+
+            if (error instanceof QueryFailedError) {
+                if (error.message.includes('Duplicate entry')) {
+                    throw new ConflictException(
+                        'Ya existe una feria con el mismo nombre y fecha. Por favor, verifica los datos e intenta nuevamente.'
+                    );
+                }
+            }
+            if (error instanceof ConflictException) {
+                throw error;
+            }
+
+            throw new InternalServerErrorException('Error interno del servidor al crear la feria');
+        } finally {
+            await queryRunner.release();
+        }
     }
 
     async getAll() {

--- a/src/modules/fairs/services/stand.service.ts
+++ b/src/modules/fairs/services/stand.service.ts
@@ -2,18 +2,18 @@ import { Injectable } from "@nestjs/common";
 import { Stand } from "../entities/stand.entity";
 import { Fair } from "../entities/fair.entity";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { QueryRunner, Repository } from "typeorm";
 @Injectable()
 export class StandService {
     constructor(
         @InjectRepository(Stand)
         private standRepository: Repository<Stand>,
         @InjectRepository(Fair)
-        private fairRepository: Repository<Fair>
+        private fairRepository: Repository<Fair>,
     ) { }
 
-    async createInitialStands(fairId: number, capacity: number) {
-        const fair = await this.fairRepository.findOne({ where: { id_fair: fairId } });
+    async createInitialStands(fairId: number, capacity: number, queryRunner: QueryRunner) {
+        const fair = await queryRunner.manager.findOne(Fair,{ where: { id_fair: fairId } });
         if (!fair) {
             throw new Error(`Feria con ID ${fairId} no encontrada`);
         }
@@ -25,7 +25,7 @@ export class StandService {
                 fair: fair
             });
         }
-        return await this.standRepository.save(standsToCreate);
+        return await queryRunner.manager.save(Stand, standsToCreate);
     }
 
     async adjustStandsToCapacity(fairId: number, newCapacity: number) {


### PR DESCRIPTION
Lógica de transacción para evitar duplicados en ferias por nombre y fecha.