### PR TITLE
Establecer métricas de proyecto en 0 por defecto

### DIFF
--- a/src/modules/projects/dto/createProject.dto.ts
+++ b/src/modules/projects/dto/createProject.dto.ts
@@ -34,21 +34,21 @@ export class CreateProjectDto {
     @IsString({ message: 'La ubicación debe ser una cadena de texto' })
     Location: string;
 
-    @IsNotEmpty({ message: 'El valor de la métrica es obligatorio' })
+    @IsOptional()
     @Type(() => Number)
     @IsInt({ message: 'El valor de la métrica debe ser un número entero' })
     @Min(0, { message: 'El valor de la métrica debe ser mayor o igual a 0' })
-    METRIC_TOTAL_BENEFICIATED: number;
+    METRIC_TOTAL_BENEFICIATED: number = 0;
 
-    @IsNotEmpty({ message: 'El valor de la métrica es obligatorio' })
+    @IsOptional()
     @Type(() => Number)
     @IsInt({ message: 'El valor de la métrica debe ser un número entero' })
     @Min(0, { message: 'El valor de la métrica debe ser mayor o igual a 0' })
-    METRIC_TOTAL_WASTE_COLLECTED: number;
+    METRIC_TOTAL_WASTE_COLLECTED: number = 0;
 
-    @IsNotEmpty({ message: 'El valor de la métrica es obligatorio' })
+    @IsOptional()
     @Type(() => Number)
     @IsInt({ message: 'El valor de la métrica debe ser un número entero' })
     @Min(0, { message: 'El valor de la métrica debe ser mayor o igual a 0' })
-    METRIC_TOTAL_TREES_PLANTED: number;
+    METRIC_TOTAL_TREES_PLANTED: number = 0;
 }

--- a/src/modules/projects/dto/updateProject.dto.ts
+++ b/src/modules/projects/dto/updateProject.dto.ts
@@ -38,21 +38,21 @@ export class UpdateProjectDto {
     @IsBoolean()
     Active: boolean;
 
-    @IsOptional({ message: 'El valor de la métrica es obligatorio' })
+    @IsOptional()
     @Type(() => Number)
     @IsInt({ message: 'El valor de la métrica debe ser un número entero' })
     @Min(0, { message: 'El valor de la métrica debe ser mayor o igual a 0' })
-    METRIC_TOTAL_BENEFICIATED: number;
+    METRIC_TOTAL_BENEFICIATED?: number = 0;
 
-    @IsOptional({ message: 'El valor de la métrica es obligatorio' })
+    @IsOptional()
     @Type(() => Number)
     @IsInt({ message: 'El valor de la métrica debe ser un número entero' })
     @Min(0, { message: 'El valor de la métrica debe ser mayor o igual a 0' })
-    METRIC_TOTAL_WASTE_COLLECTED: number;
+    METRIC_TOTAL_WASTE_COLLECTED?: number = 0;
 
-    @IsOptional({ message: 'El valor de la métrica es obligatorio' })
+    @IsOptional()
     @Type(() => Number)
     @IsInt({ message: 'El valor de la métrica debe ser un número entero' })
     @Min(0, { message: 'El valor de la métrica debe ser mayor o igual a 0' })
-    METRIC_TOTAL_TREES_PLANTED: number;
+    METRIC_TOTAL_TREES_PLANTED?: number = 0;
 }

--- a/src/modules/projects/services/project.service.ts
+++ b/src/modules/projects/services/project.service.ts
@@ -50,9 +50,9 @@ export class ProjectService implements IProjectService {
         End_date: createprojectDto.End_date,
         Target_population: createprojectDto.Target_population,
         Location: createprojectDto.Location,
-        METRIC_TOTAL_BENEFICIATED: createprojectDto.METRIC_TOTAL_BENEFICIATED,
-        METRIC_TOTAL_WASTE_COLLECTED: createprojectDto.METRIC_TOTAL_WASTE_COLLECTED,
-        METRIC_TOTAL_TREES_PLANTED: createprojectDto.METRIC_TOTAL_TREES_PLANTED,
+        METRIC_TOTAL_BENEFICIATED: 0,
+        METRIC_TOTAL_WASTE_COLLECTED: 0,
+        METRIC_TOTAL_TREES_PLANTED: 0,
         Active: false,
         Status: ProjectStatus.PENDING
       });
@@ -129,10 +129,6 @@ export class ProjectService implements IProjectService {
       if (updateProjectDto.Target_population) updateData.Target_population = updateProjectDto.Target_population;
       if (updateProjectDto.Location) updateData.Location = updateProjectDto.Location;
       if (updateProjectDto.Active !== undefined) updateData.Active = updateProjectDto.Active;
-      if (updateProjectDto.METRIC_TOTAL_TREES_PLANTED !== undefined) updateData.METRIC_TOTAL_TREES_PLANTED = updateProjectDto.METRIC_TOTAL_TREES_PLANTED;
-      if (updateProjectDto.METRIC_TOTAL_WASTE_COLLECTED !== undefined) updateData.METRIC_TOTAL_WASTE_COLLECTED = updateProjectDto.METRIC_TOTAL_WASTE_COLLECTED;
-      if (updateProjectDto.METRIC_TOTAL_BENEFICIATED !== undefined) updateData.METRIC_TOTAL_BENEFICIATED = updateProjectDto.METRIC_TOTAL_BENEFICIATED;
-
 
       if (images && images.length > 0) {
         console.log(`📁 Procesando ${images.length} imágenes para actualización`);


### PR DESCRIPTION
Las métricas ahora son opcionales en los DTOs de creación y actualización, con un valor por defecto de 0 para asegurar la inicialización.

Detalles:

- Los DTOs (createProject.dto.ts y updateProject.dto.ts) definen las métricas como opcionales.

- project.service.ts: 'createProject' siempre inicializa las métricas en 0.

- project.service.ts: Se eliminó la lógica de actualización de métricas en 'updateProject'.

  Esto se hizo porque la lógica correcta para modificar  las métricas de un proyecto está encapsulada y aplicada en los métodos de activity, no en la actualización directa del proyecto.