### PR TITLE
fix(news): corregir fuga de datos, validar imagen al publicar y orden…

### DIFF
--- a/src/modules/news/dto/create-news.dto.ts
+++ b/src/modules/news/dto/create-news.dto.ts
@@ -1,4 +1,5 @@
-import { IsNotEmpty, IsString, IsUrl, IsBoolean, IsOptional} from 'class-validator';
+import { IsNotEmpty, IsString, IsOptional, IsEnum } from 'class-validator';
+import { NewsStatus } from '../entities/news.entity';
 
 export class CreateNewsDto {
     @IsNotEmpty()
@@ -7,15 +8,15 @@ export class CreateNewsDto {
 
     @IsNotEmpty()
     @IsString()
-    content: string;            
-
-    @IsNotEmpty()
-    @IsUrl()
-    image_url: string;   
+    content: string;
 
     @IsNotEmpty()
     @IsString()
-    author: string; 
+    author: string;
+
+    @IsOptional()
+    @IsEnum(NewsStatus)
+    status?: NewsStatus;
 }
 
     

--- a/src/modules/news/news.controller.ts
+++ b/src/modules/news/news.controller.ts
@@ -58,7 +58,8 @@ export class NewsController {
   }
 
   @Get(':id')
-  @Public()
+  @UseGuards(RoleGuard)
+  @Roles(UserRole.SUPER_ADMIN, UserRole.GENERAL_ADMIN, UserRole.CONTENT_ADMIN)
   getOne(@Param('id', ParseIntPipe) id: number) {
     return this.newsService.getOne(id);
   }

--- a/src/modules/news/news.service.ts
+++ b/src/modules/news/news.service.ts
@@ -1,5 +1,5 @@
 // news.service.ts
-import { Injectable, NotFoundException, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, NotFoundException, InternalServerErrorException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { News, NewsStatus } from './entities/news.entity';
@@ -166,6 +166,13 @@ export class NewsService {
 
     async updateStatus(id_news: number, { status }: NewsStatusDto): Promise<News> {
         const news = await this.getOne(id_news);
+
+        if (status === NewsStatus.PUBLISHED && !news.image_url?.trim()) {
+            throw new BadRequestException(
+                'No se puede publicar una noticia sin imagen. Agrega una imagen antes de publicar.'
+            );
+        }
+
         news.status = status;
         return this.newsRepository.save(news);
     }
@@ -177,24 +184,25 @@ export class NewsService {
 
         try {
             const news = await this.newsRepository.findOne({ where: { id_news } });
-            
+
             if (!news) {
                 throw new NotFoundException(`La noticia con ID ${id_news} no existe`);
             }
 
-            // Eliminar imagen de Google Drive si existe
-            if (news.image_url && news.image_url.trim() !== '') {
-                const fileId = this.googleDriveService.extractFileIdFromUrl(news.image_url);
-                if (fileId) {
-                    console.log('🗑️ Eliminando imagen de Google Drive:', fileId);
-                    await this.googleDriveService.deleteFile(fileId);
-                    console.log('✅ Imagen eliminada de Google Drive');
-                }
-            }
+            const fileIdToDelete = (news.image_url && news.image_url.trim() !== '')
+                ? this.googleDriveService.extractFileIdFromUrl(news.image_url)
+                : null;
 
             await queryRunner.manager.delete(News, id_news);
             await queryRunner.commitTransaction();
             console.log('✅ Noticia eliminada exitosamente');
+
+            // Eliminar imagen de Drive después del commit (fire-and-forget)
+            if (fileIdToDelete) {
+                this.googleDriveService.deleteFile(fileIdToDelete)
+                    .then(() => console.log('✅ Imagen eliminada de Google Drive'))
+                    .catch(error => console.error('⚠️ No se pudo eliminar imagen de Drive:', error.message));
+            }
 
         } catch (error) {
             await queryRunner.rollbackTransaction();


### PR DESCRIPTION
… de eliminación en Drive

  - Eliminar @Public() en getOne y agregar RoleGuard para evitar exponer borradores
  - Remover image_url del CreateNewsDto (la genera el backend) y agregar status opcional
  - Agregar validación de imagen requerida al cambiar estado a published en updateStatus
  - Mover eliminación de imagen de Drive al post-commit en delete(), igual que update()